### PR TITLE
Some fixes for 2023042500+

### DIFF
--- a/sdvx@asphyxia/handlers/common.ts
+++ b/sdvx@asphyxia/handlers/common.ts
@@ -71,7 +71,7 @@ export const common: EPR = async (info, data, send) => {
     }
     let songs = [];
     const gameVersion = getVersion(info);
-    let songNum = 2000;
+    let songNum = 3000;
     if(gameVersion === 2) songNum = 554;
     if(gameVersion === 3) songNum = 954;
     if(gameVersion === 4) songNum = 1368;

--- a/sdvx@asphyxia/handlers/features.ts
+++ b/sdvx@asphyxia/handlers/features.ts
@@ -63,6 +63,7 @@ export const hiscore: EPR = async (info, data, send) => {
 
 export const rival: EPR = async (info, data, send) => {
   const refid = $(data).str('refid');
+  const version = parseInt(info.model.split(":")[4]);
   if (!refid) return send.deny();
 
   const rivals = (
@@ -79,7 +80,8 @@ export const rival: EPR = async (info, data, send) => {
           music: (
             await DB.Find<MusicRecord>(p.__refid, { collection: 'music' })
           ).map(r => ({
-            param: K.ARRAY('u32', [r.mid, r.type, r.score, r.clear, r.grade]),
+            // Changes were somehow made in the order of the field for the version 2023042500
+            param: K.ARRAY('u32', version < 2023042500 ? [r.mid, r.type, r.score, r.clear, r.grade] : [r.mid, r.type, r.score, r.grade, r.clear]),
           })),
         };
       })


### PR DESCRIPTION
Hi !

I noticed that in the 2023042500 version in the in-game leaderboard, another player had scores that didn't clear some maps, but UC and PUC logos were appearing. Apparently, two fields in the array of the rival packet were swapped, so I fixed that depending on the version of the game. It happened to fix the random crashes when scrolling on some songs, maybe because the swapped fields weren't therefore correct for the game.
I also increased the maximum number of songs to 3000, to allow songs with ids bigger than 2000 to be unlocked as well.