### PR TITLE
Update achievements.js

### DIFF
--- a/sdvx@asphyxia/webui/asset/js/achievements.js
+++ b/sdvx@asphyxia/webui/asset/js/achievements.js
@@ -31,7 +31,12 @@ async function populateAch(listType) {
 			if(ach['rtype'] === 'pcb') {
 				reward = ach['rid'] + " PCB"
 			} else if(ach['rtype'] === 'aptitle') {
-				reward = "Appeal Title \"" + aptitlelist.find(e => parseInt(e['value']) === ach['rid'])['name'] + "\""
+				let aptitle = aptitlelist.find(e => parseInt(e['value']) === ach['rid'])
+				if (aptitle !== undefined) {
+					reward = "Appeal Title \"" + aptitle['name'] + "\""
+				} else {
+					reward = "Unknown Appeal Title"
+				}
 			}
 		} else {
 			reward = '-----'


### PR DESCRIPTION
Fix issue where achievements page wouldn't render when using older game data than achievements.json expects (failure to lookup akaname for aptitle reward)

````
jquery-3.5.1.min.js:2  Uncaught TypeError: Cannot read properties of undefined (reading 'name')
    at achievements.js:34:92
    at Array.forEach (<anonymous>)
    at populateAch (achievements.js:27:26)
    at HTMLDocument.<anonymous> (achievements.js:15:11)
````